### PR TITLE
web: fix firefox title disappearing on resize bug

### DIFF
--- a/web/src/Card/View.elm
+++ b/web/src/Card/View.elm
@@ -83,7 +83,6 @@ view =
                         , Font.color <| fromRgb255 name.color
                         , width (fill |> maximum name.maxWidth)
                         , paddingEach { edges | top = name.paddingTop }
-                        , clip
                         ]
                         [ html
                             (Html.div


### PR DESCRIPTION
[removed clip attribute](https://package.elm-lang.org/packages/mdgriffith/elm-ui/latest/Element#clip)